### PR TITLE
Fix/upload error 临时绕过前端鉴权逻辑以修复文档上传失败问题

### DIFF
--- a/lightrag_webui/src/api/lightrag.ts
+++ b/lightrag_webui/src/api/lightrag.ts
@@ -135,12 +135,12 @@ const axiosInstance = axios.create({
 // Interceptor: add api key and check authentication
 axiosInstance.interceptors.request.use((config) => {
   const apiKey = useSettingsStore.getState().apiKey
-  const token = localStorage.getItem('LIGHTRAG-API-TOKEN');
+  // const token = localStorage.getItem('LIGHTRAG-API-TOKEN');
 
   // Always include token if it exists, regardless of path
-  if (token) {
-    config.headers['Authorization'] = `Bearer ${token}`
-  }
+  // if (token) {
+  //   config.headers['Authorization'] = `Bearer ${token}`
+  // }
   if (apiKey) {
     config.headers['X-API-Key'] = apiKey
   }
@@ -154,11 +154,11 @@ axiosInstance.interceptors.response.use(
     if (error.response) {
       if (error.response?.status === 401) {
         // For login API, throw error directly
-        if (error.config?.url?.includes('/login')) {
-          throw error;
-        }
+        // if (error.config?.url?.includes('/login')) {
+        //   throw error;
+        // }
         // For other APIs, navigate to login page
-        navigationService.navigateToLogin();
+        // navigationService.navigateToLogin();
 
         // return a reject Promise
         return Promise.reject(new Error('Authentication required'));


### PR DESCRIPTION
### **主要内容**
本次修改注释了 lightrag.ts 中的鉴权与登录跳转逻辑，避免前端在未启用后端鉴权的情况下依然发送无效 Token，导致上传接口返回 401。

### **注意事项**
**此为临时方案**，用于保证首页涉及的文档上传功能在目前开发阶段可正常使用；
后续应根据负责文档管理同学所写代码和后端最终鉴权方案再恢复或重构相关逻辑。